### PR TITLE
Harden native library extraction and loading

### DIFF
--- a/src/main/java/io/github/doblon8/jzbar/utils/NativeLoader.java
+++ b/src/main/java/io/github/doblon8/jzbar/utils/NativeLoader.java
@@ -34,7 +34,7 @@ public class NativeLoader {
         };
 
         try {
-            Path tempDir = Files.createTempDirectory("zbar-native");
+            Path tempDir = createOwnerOnlyTempDir("zbar-native");
             tempDir.toFile().deleteOnExit();
 
             for (String lib : libs) {


### PR DESCRIPTION
This PR aims to improve security when extracting and loading bundled native libraries to mitigate TOCTOU and replacement risks (as reported in sparrowwallet/drongo#29):
- creates the temporary extraction directory with owner-only permissions on POSIX
- writes libraries to a restrictive temporary file, then computes and validates a hash before use
- ensures libraries are opened and loaded with restrictive permissions (no world-writable or exec by default)

These changes try to reduce the attack surface by limiting the chance of other local processes replacing the extracted files between extract and load.