### PR TITLE
Drop support for system installed versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15-intel, macos-15, windows-2025]
-        install-zbar: [true, false]
 
     steps:
     - uses: actions/checkout@v6
@@ -23,18 +22,6 @@ jobs:
         distribution: 'temurin'
         java-version: '25'
         cache: maven
-
-    - name: Install zbar (Ubuntu)
-      if: matrix.install-zbar && startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get update && sudo apt-get install -y libzbar0
-
-    - name: Install zbar (macOS)
-      if: matrix.install-zbar && startsWith(matrix.os, 'macos')
-      run: brew install zbar
-
-    - name: Install zbar (Windows)
-      if: matrix.install-zbar && startsWith(matrix.os, 'windows')
-      run: choco install zbar
 
     - name: Build with Maven
       run: mvn -B package

--- a/src/main/java/io/github/doblon8/jzbar/bindings/zbar.java
+++ b/src/main/java/io/github/doblon8/jzbar/bindings/zbar.java
@@ -57,7 +57,7 @@ public class zbar {
     static final SymbolLookup SYMBOL_LOOKUP;
 
     static {
-        SymbolLookup lookup = null;
+        SymbolLookup lookup;
         try {
             // Try system library first
             lookup = SymbolLookup.libraryLookup(System.mapLibraryName("zbar"), LIBRARY_ARENA)

--- a/src/main/java/io/github/doblon8/jzbar/bindings/zbar.java
+++ b/src/main/java/io/github/doblon8/jzbar/bindings/zbar.java
@@ -59,20 +59,12 @@ public class zbar {
     static {
         SymbolLookup lookup;
         try {
-            // Try system library first
-            lookup = SymbolLookup.libraryLookup(System.mapLibraryName("zbar"), LIBRARY_ARENA)
-                    .or(SymbolLookup.loaderLookup())
-                    .or(Linker.nativeLinker().defaultLookup());
+            System.loadLibrary("zbar");
+            lookup = SymbolLookup.loaderLookup();
         } catch (Throwable t) {
-            // Check if the library was already loaded by the host application (e.g. via System.load)
-            SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
-            if (loaderLookup.find("zbar_image_create").isPresent()) {
-                lookup = loaderLookup.or(Linker.nativeLinker().defaultLookup());
-            } else {
-                // Fallback to bundled library
-                NativeLoader.loadZBar();
-                lookup = loaderLookup.or(Linker.nativeLinker().defaultLookup());
-            }
+            // Fallback to bundled library
+            NativeLoader.loadZBar();
+            lookup = SymbolLookup.loaderLookup().or(Linker.nativeLinker().defaultLookup());
         }
         SYMBOL_LOOKUP = lookup;
     }

--- a/src/main/java/io/github/doblon8/jzbar/bindings/zbar.java
+++ b/src/main/java/io/github/doblon8/jzbar/bindings/zbar.java
@@ -57,16 +57,12 @@ public class zbar {
     static final SymbolLookup SYMBOL_LOOKUP;
 
     static {
-        SymbolLookup lookup;
         try {
             System.loadLibrary("zbar");
-            lookup = SymbolLookup.loaderLookup();
         } catch (Throwable t) {
-            // Fallback to bundled library
-            NativeLoader.loadZBar();
-            lookup = SymbolLookup.loaderLookup().or(Linker.nativeLinker().defaultLookup());
+            NativeLoader.loadZBar(); // Fallback to bundled library
         }
-        SYMBOL_LOOKUP = lookup;
+        SYMBOL_LOOKUP = SymbolLookup.loaderLookup().or(Linker.nativeLinker().defaultLookup());
     }
 
     public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;


### PR DESCRIPTION
This PR removes support for loading system-installed versions of the `zbar` library. Now we always use `System.loadLibrary` with a fallback to the bundled library.

This change addresses a point raised by @craigraw in https://github.com/doblon8/jzbar/issues/8#issuecomment-4072805445_, where he notes:

> Using system-installed versions of libraries is generally not a good idea for security sensitive software. It means a reproducible build is impossible, and you can't reason with clarity on the integrity of the application.